### PR TITLE
Bug fix in `from_prometheus_api_metric_response`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,37 @@ Then, we execute our query and get the result using ``PrometheusResult.from_quer
 ```python
     result = PrometheusResult.from_query_builder(promql_query, connection)
 ```
+
+## Sample Program
+
+```python
+    #!/usr/bin/env python3
+
+    from pypromql.connection import PrometheusConnection
+    from pypromql.result import PrometheusResult
+    from pypromql.query import Query
+
+    # create a connection to the prometheus server
+    conn = PrometheusConnection(prometheus_base_url="http://192.168.1.18:9090")
+
+    # an example metric from node_exporter
+    query = Query.metric('node_cpu_seconds_total')
+    # filter by user and system mode cpu times
+    query.label(label_name="mode", label_value="user|system", match_operator="=~")
+    # choose only the first cpu.
+    query.label("cpu", "0", "=")
+    # get the counter values for the past 5 minutes
+    query.before_time_duration("5m")
+
+    # display the query.
+    print(query)
+
+    # execute the query.
+    result = PrometheusResult.from_query_builder(query, conn)
+
+    # iterate over the results and display the values.
+    for metric in result.metrics:
+        print(metric.labels)
+        print(metric.value)
+        print(metric.timestamp)
+```

--- a/pypromql/result/prometheus_metric.py
+++ b/pypromql/result/prometheus_metric.py
@@ -15,6 +15,11 @@ class Metric:
     @classmethod
     def from_prometheus_api_metric_response(cls, prometheus_api_metric_response: dict):
         labels = prometheus_api_metric_response['metric']
-        timestamp = prometheus_api_metric_response['value'][0]
-        value = float(prometheus_api_metric_response['value'][1])
+        # the attribute has changed from 'value' to 'values'
+        # moreover, 'values' carry a list of tuples @<timestamp, value>.
+        # Therefore, it requires to scan through the list to collect the tuple items.
+        timestamp = [value[0] for value in prometheus_api_metric_response['values']]
+        value = [float(value[1]) for value in prometheus_api_metric_response['values']]
+        #timestamp = prometheus_api_metric_response['value'][0]
+        #value = float(prometheus_api_metric_response['value'][1])
         return cls(timestamp=timestamp, value=value, labels=labels)


### PR DESCRIPTION
In `pypromql/result/prometheus_metric.py`, the response from the Prometheus server has changed.  Please see my inline code comments.

`@classmethod`
`def from_prometheus_api_metric_response(cls, prometheus_api_metric_response: dict):`
`       labels = prometheus_api_metric_response['metric']`
`        # the attribute has changed from 'value' to 'values'`
`        # moreover, 'values' carry a list of tuples @<timestamp, value>.`
`        # Therefore, it requires to scan through the list to collect the tuple items.`
`        timestamp = [value[0] for value in prometheus_api_metric_response['values']]`
`        value = [float(value[1]) for value in prometheus_api_metric_response['values']]`
`        #timestamp = prometheus_api_metric_response['value'][0]`
`        #value = float(prometheus_api_metric_response['value'][1])`
`        return cls(timestamp=timestamp, value=value, labels=labels)`

Also, I have added an example script to READEM to pull metrics from the Prometheus server.